### PR TITLE
Add support for Yarn Workspaces flag

### DIFF
--- a/eslint-prettier-config.sh
+++ b/eslint-prettier-config.sh
@@ -16,9 +16,10 @@ NC='\033[0m' # No Color
 # Package Manager Prompt
 echo
 echo "Which package manager are you using?"
-select package_command_choices in "Yarn" "npm" "Cancel"; do
+select package_command_choices in "Yarn" "Yarn Workspaces" "npm" "Cancel"; do
   case $package_command_choices in
     Yarn ) pkg_cmd='yarn add'; break;;
+    "Yarn Workspaces" ) pkg_cmd='yarn add -W'; break;;
     npm ) pkg_cmd='npm install'; break;;
     Cancel ) exit;;
   esac


### PR DESCRIPTION
When using Yarn Workspaces, the `-W` flag is necessary in order to install a package in the root.

This change would allow the user to pick "Yarn Workspaces" as an option :)