### PR TITLE
👌 IMPROVE: ReadMe & Setting MaxLen Default to 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Once files are created, you may edit to your liking.
 
 ```
 {
-"printWidth": (SET BY USER),
+  "printWidth": (SET BY USER),
   "singleQuote": true,
   "trailingComma": (SET BY USER)
 }

--- a/eslint-prettier-config.sh
+++ b/eslint-prettier-config.sh
@@ -53,14 +53,15 @@ finished=false
 
 # Max Line Length Prompt
 while ! $finished; do
-  read -p "What max line length do you want to set for ESLint and Prettier? (Recommendation: 80)"
+  read -p "What max line length do you want to set for ESLint and Prettier? (Default Recommendation: 80)"
   if [[ $REPLY =~ ^[0-9]{2,3}$ ]]; then
     max_len_val=$REPLY
-    finished=true
-    echo
   else
-    echo -e "${YELLOW}Please choose a max length of two or three digits, e.g. 80 or 100 or 120${NC}"
+    echo -e "${YELLOW}Setting default value to 80${NC}"
+    max_len_val=80
   fi
+  finished=true
+  echo
 done
 
 # Trailing Commas Prompt


### PR DESCRIPTION
Hi @paulolramos 

This PR Improves ::
- Fix tab missing to Readme File.
- Added an option to default the max-length to 80. So that user can skip this step.
